### PR TITLE
Improvement in executives list page

### DIFF
--- a/src/components/List/helpers.tsx
+++ b/src/components/List/helpers.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { format, fromUnixTime, formatDistance, differenceInMonths } from 'date-fns'
+import { format, fromUnixTime, differenceInMonths } from 'date-fns'
 import { timeLeft } from '../../utils'
 
 //Common components
@@ -65,23 +65,25 @@ export const Executivecolumns = () => {
       Header: 'Status',
       accessor: 'status',
       Cell: ({ row }) =>
-        row.original.casted
-          ? 'Passed'
-          : differenceInMonths(new Date(), fromUnixTime(row.original.timestamp)) < 12
-          ? 'Open'
-          : 'Limbo',
+        row.original.casted ? (
+          <span style={{ color: '#00ba9c' }}>Passed</span>
+        ) : differenceInMonths(new Date(), fromUnixTime(row.original.timestamp)) < 12 ? (
+          <span style={{ color: '#fac202' }}>Open</span>
+        ) : (
+          'Limbo'
+        ),
+      width: 100,
     },
     {
       Header: 'Name',
-      accessor: row => row.title || row.id,
-    },
-    {
-      Header: 'Overview',
-      accessor: 'proposal_blurb',
+      Cell: ({ row }) => (
+        <span data-tip={row.original.title || row.original.id}>{row.original.title || row.original.id}</span>
+      ),
     },
     {
       Header: 'MKR in support',
       accessor: row => Number(row.approvals).toFixed(2),
+      width: 100,
     },
     {
       Header: 'Started',
@@ -89,14 +91,16 @@ export const Executivecolumns = () => {
       accessor: row => (!row.timestamp ? new Date(row.date) : fromUnixTime(row.timestamp)),
       sortType: 'datetime',
       Cell: ({ row }) =>
-        !row.original.timestamp
-          ? formatDistance(new Date(row.original.date), new Date(), { addSuffix: true })
-          : formatDistance(fromUnixTime(row.original.timestamp), new Date(), { addSuffix: true }),
+        row.original.timestamp
+          ? format(fromUnixTime(row.original.timestamp), 'dd MMM yy')
+          : format(new Date(row.date), 'dd MMM yy'),
+      width: 100,
     },
     {
       Header: 'Executed',
       accessor: 'executed',
       Cell: ({ row }) => (row.original.casted ? format(fromUnixTime(row.original.casted), 'dd MMM yy') : 'NO'),
+      width: 100,
     },
   ]
 }

--- a/src/containers/Executive/index.tsx
+++ b/src/containers/Executive/index.tsx
@@ -72,7 +72,7 @@ function ExecutiveInfo(props) {
         })
     }
   }, [excutivesData.data])
-  if (excutivesData.loading || gResult.loading) return <Loading />
+  if (excutivesData.loading || gResult.loading || data.length === 0) return <Loading />
   if (excutivesData.error || gResult.error) return <Error />
 
   return (

--- a/src/containers/Polls/queries.tsx
+++ b/src/containers/Polls/queries.tsx
@@ -1,7 +1,7 @@
 import gql from 'graphql-tag'
 
 const pollsDetailFragment = gql`
-  fragment pollsDetail on Poll {
+  fragment pollsDetailTotal on Poll {
     id
     creator
     url
@@ -27,7 +27,7 @@ export const GOVERNANCE_INFO_QUERY = gql`
 export const POLLS_FIRST_QUERY = gql`
   query GetPollsData($polls: Int!) {
     polls(first: $polls) {
-      ...pollsDetail
+      ...pollsDetailTotal
     }
   }
   ${pollsDetailFragment}

--- a/src/types/generatedGQL.ts
+++ b/src/types/generatedGQL.ts
@@ -116,18 +116,6 @@ export interface GetGovernanceInfo {
 // GraphQL query operation: GetPolls
 // ====================================================
 
-export interface GetPolls_polls_votes {
-  __typename: 'PollVote'
-  /**
-   *  Voters's Address
-   */
-  voter: any
-  /**
-   *  Selected option
-   */
-  option: any
-}
-
 export interface GetPolls_polls {
   __typename: 'Poll'
   /**
@@ -139,11 +127,6 @@ export interface GetPolls_polls {
   pollId: any
   startDate: any
   endDate: any
-  /**
-   *  Number votes
-   */
-  votesCount: any
-  votes: GetPolls_polls_votes[] | null
 }
 
 export interface GetPolls {
@@ -158,18 +141,6 @@ export interface GetPolls {
 // GraphQL query operation: getHomeData
 // ====================================================
 
-export interface getHomeData_polls_votes {
-  __typename: 'PollVote'
-  /**
-   *  Voters's Address
-   */
-  voter: any
-  /**
-   *  Selected option
-   */
-  option: any
-}
-
 export interface getHomeData_polls {
   __typename: 'Poll'
   /**
@@ -181,11 +152,6 @@ export interface getHomeData_polls {
   pollId: any
   startDate: any
   endDate: any
-  /**
-   *  Number votes
-   */
-  votesCount: any
-  votes: getHomeData_polls_votes[] | null
 }
 
 export interface getHomeData_executives {
@@ -761,18 +727,6 @@ export interface executivesDetail {
 // GraphQL fragment: pollsDetail
 // ====================================================
 
-export interface pollsDetail_votes {
-  __typename: 'PollVote'
-  /**
-   *  Voters's Address
-   */
-  voter: any
-  /**
-   *  Selected option
-   */
-  option: any
-}
-
 export interface pollsDetail {
   __typename: 'Poll'
   /**
@@ -784,11 +738,6 @@ export interface pollsDetail {
   pollId: any
   startDate: any
   endDate: any
-  /**
-   *  Number votes
-   */
-  votesCount: any
-  votes: pollsDetail_votes[] | null
 }
 
 /* tslint:disable */
@@ -827,6 +776,44 @@ export interface pollsDetailPage {
    */
   votesCount: any
   votes: pollsDetailPage_votes[] | null
+}
+
+/* tslint:disable */
+/* eslint-disable */
+// This file was automatically generated and should not be edited.
+
+// ====================================================
+// GraphQL fragment: pollsDetailTotal
+// ====================================================
+
+export interface pollsDetailTotal_votes {
+  __typename: 'PollVote'
+  /**
+   *  Voters's Address
+   */
+  voter: any
+  /**
+   *  Selected option
+   */
+  option: any
+}
+
+export interface pollsDetailTotal {
+  __typename: 'Poll'
+  /**
+   *  Equals to: <Poll ID>
+   */
+  id: string
+  creator: any | null
+  url: string | null
+  pollId: any
+  startDate: any
+  endDate: any
+  /**
+   *  Number votes
+   */
+  votesCount: any
+  votes: pollsDetailTotal_votes[] | null
 }
 
 /* tslint:disable */


### PR DESCRIPTION
**Executives list page**

- Colour code each list item based on the status ‘Passed’ (pale green) or ‘Open’ (pale yellow).
- Should allow more space for the name of the poll. Full title should display in a 'mouse-over' box
- Overview column should be removed.
- ‘Started’ Column should display as a date in the same way as the ‘Executed’ Column.