### PR TITLE
Make poll details show new data

### DIFF
--- a/src/components/PollDetails/helpers.tsx
+++ b/src/components/PollDetails/helpers.tsx
@@ -1,8 +1,8 @@
 import {
   fromUnixTime,
+  getUnixTime,
   format,
-  formatDistance,
-  formatDistanceToNow,
+  differenceInDays,
   addHours,
   startOfHour,
   endOfHour,
@@ -12,25 +12,60 @@ import {
 import { shortenAccount, timeLeft, getVoterBalances, getPollData } from '../../utils'
 import { getVoterAddresses, getPollDataWithoutBalances } from './data'
 import { LAST_YEAR } from '../../constants'
-import { getUnixTime } from 'date-fns/esm'
 
 export const defaultFilters = {
   votersVsMkr: LAST_YEAR,
 }
 
-export const getPollTableData = poll => {
+const getTimeOpened = (from, to) => {
+  const diffDays = differenceInDays(to, from)
+  const diffHours = differenceInHours(to, from) % 24
+  if (diffDays > 0 && diffHours > 0) {
+    return `${diffDays} ${diffDays === 1 ? 'day' : 'days'} ${diffHours} ${diffHours === 1 ? 'hour' : 'hours'}`
+  } else if (diffDays <= 0) return `${diffHours} ${diffHours === 1 ? 'hour' : 'hours'}`
+  else return `${diffDays} ${diffDays === 1 ? 'day' : 'days'}`
+}
+
+const getKeysWithHighestValue = (o, n) => {
+  var keys = Object.keys(o)
+  keys.sort(function(a, b) {
+    return o[b] - o[a]
+  })
+  return keys.slice(0, n)
+}
+
+const getTimeLeftText = time => {
+  if (time[0].time.days > 0 && time[0].time.hours > 0) {
+    return `${time[0].time.days} ${time[0].time.days === 1 ? 'day' : 'days'} ${time[0].time.hours} ${
+      time[0].time.hours === 1 ? 'hour' : 'hours'
+    }`
+  } else if (time[0].time.days <= 0) return `${time[0].time.hours} ${time[0].time.hours === 1 ? 'hour' : 'hours'}`
+  else return `${time[0].time.days} ${time[0].time.days === 1 ? 'day' : 'days'}`
+}
+
+export const getPollTableData = (poll, mkrDistributionData) => {
+  const lastDistValue = mkrDistributionData[mkrDistributionData.length - 1]
+  const { Abstein, endDate, from, to, label, ...rest } = lastDistValue
+  const winOption = getKeysWithHighestValue(rest, 1)[0]
+  const time = getTimeLeftData(poll.startDate, poll.endDate)
   return [
-    { value: shortenAccount(poll.source.toLowerCase()), label: 'Source' },
-    { value: format(fromUnixTime(poll.startDate), 'P'), label: 'Started' },
-    { value: Number(poll.votesCount) === 0 ? 'No' : 'Yes', label: 'Voted' },
-    { value: timeLeft(poll.endDate) === 'Ended' ? 'Yes' : 'No', label: 'Ended' },
-    { value: timeLeft(poll.endDate) === 'Ended' ? 'Closed' : 'Active', label: 'Status' },
+    { value: shortenAccount(poll.source.toLowerCase()), label: 'Poll Address' },
+    { value: format(fromUnixTime(poll.startDate), 'P'), label: 'Start Date' },
+    { value: timeLeft(poll.endDate) === 'Ended' ? 'Closed' : 'Open', label: 'Status' },
     {
       value:
-        timeLeft(poll.endDate) === 'Ended'
-          ? formatDistance(fromUnixTime(poll.startDate), fromUnixTime(poll.endDate), { addSuffix: false })
-          : formatDistanceToNow(fromUnixTime(poll.startDate), { addSuffix: false }),
+        time[0].text === 'Ended'
+          ? getTimeOpened(fromUnixTime(poll.startDate), fromUnixTime(poll.endDate))
+          : getTimeOpened(fromUnixTime(poll.startDate), Date.now()),
       label: 'Time opened',
+    },
+    {
+      value: time[0].text === 'Ended' ? 'Ended' : getTimeLeftText(time),
+      label: 'Time Remaining',
+    },
+    {
+      value: winOption,
+      label: 'Winning Option',
     },
   ]
 }

--- a/src/components/PollDetails/index.tsx
+++ b/src/components/PollDetails/index.tsx
@@ -204,12 +204,16 @@ function PollDetails(props: Props) {
       <ThreeRowGrid style={{ marginBottom: '20px' }}>
         <CardStyled style={{ padding: 0 }}>
           <StrippedTableWrapper content="Details">
-            {getPollTableData(poll, mkrDistributionData).map(el => (
-              <StrippedTableRow key={el.label}>
-                <StrippedTableCell>{el.label}</StrippedTableCell>
-                <StrippedTableCell>{el.value}</StrippedTableCell>
-              </StrippedTableRow>
-            ))}
+            {mkrDistributionData.length === 0 ? (
+              <Loading />
+            ) : (
+              getPollTableData(poll, mkrDistributionData).map(el => (
+                <StrippedTableRow key={el.label}>
+                  <StrippedTableCell>{el.label}</StrippedTableCell>
+                  <StrippedTableCell>{el.value}</StrippedTableCell>
+                </StrippedTableRow>
+              ))
+            )}
           </StrippedTableWrapper>
         </CardStyled>
         <CardStyled>

--- a/src/components/PollDetails/index.tsx
+++ b/src/components/PollDetails/index.tsx
@@ -54,6 +54,8 @@ function PollDetails(props: Props) {
   const [pollPerOptionData, setPollPerOptionData] = useState<any>(pollPerOptionCached)
   const [mkrDistributionData, setMkrDistributionData] = useState<any>(mkrDistributionCached)
 
+  const timeLeftData = getTimeLeftData(poll.startDate, poll.endDate)
+
   const colors = useMemo(() => randomColor({ count: poll.options.length, seed: poll.id }), [poll.options, poll.id])
   useEffect(() => {
     if (pollPerOptionCached.length === 0) getPollPerOptionData(poll).then(data => setPollPerOptionData(data))
@@ -75,7 +77,7 @@ function PollDetails(props: Props) {
     },
     chart: {
       timeLeft: {
-        data: getTimeLeftData(poll.startDate, poll.endDate),
+        data: timeLeftData,
         component: props => <TimeLeft content="Time left" component="timeLeft" {...props} />,
       },
       votersDistribution: {
@@ -202,7 +204,7 @@ function PollDetails(props: Props) {
       <ThreeRowGrid style={{ marginBottom: '20px' }}>
         <CardStyled style={{ padding: 0 }}>
           <StrippedTableWrapper content="Details">
-            {getPollTableData(poll).map(el => (
+            {getPollTableData(poll, mkrDistributionData).map(el => (
               <StrippedTableRow key={el.label}>
                 <StrippedTableCell>{el.label}</StrippedTableCell>
                 <StrippedTableCell>{el.value}</StrippedTableCell>


### PR DESCRIPTION
**Poll details page**

The Poll Details tile should show the following:

- Poll Address - Address of the polling emitter. (Should match vote.makerdao.com)
- Start Date - Date on which the proposal was posted.
- Status - Open/Closed
- Time Open - How many days + hours has this been open.
- Time Remaining - How many days + hours are remaining before this closes.
- Winning Option - Shows the currently winning option if open, the winning option if closed.