### PR TITLE
Feedback M5 and M6

### DIFF
--- a/src/components/Home/HomeDetail.tsx
+++ b/src/components/Home/HomeDetail.tsx
@@ -169,7 +169,7 @@ function HomeDetail(props: Props) {
           <HomeTable
             expanded
             handleRow={getVote}
-            content="Uncasted Executives"
+            content="Uncast Executives"
             component="uncastedExecutives"
             {...props}
           />
@@ -454,7 +454,7 @@ function HomeDetail(props: Props) {
           <HomeTable handleRow={getVote} content="Top Executives" component="executives" />
         </TableCardStyled>
         <TableCardStyled style={{ padding: 0 }}>
-          <HomeTable handleRow={getVote} content="Uncasted Executives" component="uncastedExecutives" />
+          <HomeTable handleRow={getVote} content="Uncast Executives" component="uncastedExecutives" />
         </TableCardStyled>
       </TwoRowGrid>
       <TwoRowGrid style={{ marginBottom: '20px' }}>

--- a/src/components/List/helpers.tsx
+++ b/src/components/List/helpers.tsx
@@ -14,6 +14,23 @@ const Loading = () => (
 export const Pollcolumns = () => {
   return [
     {
+      Header: 'Status',
+      Filter: SelectColumnFilter,
+      filter: 'includes',
+      accessor: row => (timeLeft(row.endDate) === 'Ended' ? 'Ended' : 'Active'),
+      Cell: ({ row }) => timeLeft(row.original.endDate),
+      width: 100,
+    },
+    {
+      Header: 'Category',
+      Filter: SelectColumnFilter,
+      separator: true,
+      show: false,
+      filter: 'includes',
+      accessor: row => 'uncategorized',
+      width: 100,
+    },
+    {
       Header: 'Name',
       separator: true,
       accessor: 'title',
@@ -50,28 +67,12 @@ export const Pollcolumns = () => {
       width: 80,
     },
     {
-      Header: 'Total MKR Staked',
-      accessor: 'total-mkr',
-      disableFilters: true,
-      sortType: (a, b) => a.original.plurality.totalMkr - b.original.plurality.totalMkr,
-      Cell: ({ row }) => (row.original.plurality ? row.original.plurality.totalMkr : <Loading />),
-      width: 80,
-    },
-    {
       Header: 'MKR Participation',
       accessor: 'participation',
       separator: true,
       disableFilters: true,
       Cell: ({ row }) => (row.original.participation ? `${row.original.participation}%` : <Loading />),
       width: 80,
-    },
-    {
-      Header: 'Category',
-      Filter: SelectColumnFilter,
-      separator: true,
-      filter: 'includes',
-      accessor: row => 'uncategorized',
-      width: 100,
     },
     {
       Header: 'Start',
@@ -89,13 +90,6 @@ export const Pollcolumns = () => {
       separator: true,
       sortType: 'datetime',
       Cell: ({ row }) => format(fromUnixTime(row.original.endDate), 'dd MMM yy'),
-      width: 100,
-    },
-    {
-      Header: 'Status',
-      Filter: SelectColumnFilter,
-      filter: 'includes',
-      accessor: row => timeLeft(row.endDate),
       width: 100,
     },
   ]
@@ -124,7 +118,7 @@ export const Executivecolumns = () => {
       id: 'status',
       Cell: ({ row }) =>
         row.original.isHat && row.original.isActive ? (
-          <span style={{ color: '#00ba9c', marginLeft: '20px' }}>
+          <span style={{ color: '#00ba9c', marginLeft: '20px', fontWeight: 700 }}>
             <span>Active</span>
           </span>
         ) : row.original.isHat ? (
@@ -132,7 +126,7 @@ export const Executivecolumns = () => {
             <span>Hat</span>
           </span>
         ) : row.original.isActive ? (
-          <span style={{ color: '#00ba9c', marginLeft: '20px' }}>Active</span>
+          <span style={{ color: '#00ba9c', marginLeft: '20px', fontWeight: 700 }}>Active</span>
         ) : row.original.casted ? (
           <span style={{ color: '#2730a0', marginLeft: '20px' }}>Passed</span>
         ) : differenceInMonths(new Date(), fromUnixTime(row.original.timestamp)) < 12 ? (
@@ -140,6 +134,14 @@ export const Executivecolumns = () => {
         ) : (
           'Limbo'
         ),
+      width: 100,
+    },
+    {
+      Header: 'Category',
+      Filter: SelectColumnFilter,
+      separator: true,
+      filter: 'includes',
+      accessor: row => 'uncategorized',
       width: 100,
     },
     {
@@ -159,14 +161,6 @@ export const Executivecolumns = () => {
       separator: true,
       disableFilters: true,
       accessor: row => Number(row.approvals).toFixed(2),
-      width: 100,
-    },
-    {
-      Header: 'Category',
-      Filter: SelectColumnFilter,
-      separator: true,
-      filter: 'includes',
-      accessor: row => 'uncategorized',
       width: 100,
     },
     {

--- a/src/components/List/helpers.tsx
+++ b/src/components/List/helpers.tsx
@@ -140,6 +140,7 @@ export const Executivecolumns = () => {
       Header: 'Category',
       Filter: SelectColumnFilter,
       separator: true,
+      show: false,
       filter: 'includes',
       accessor: row => 'uncategorized',
       width: 100,

--- a/src/components/PollDetails/Charts/PollPerOptionChart.tsx
+++ b/src/components/PollDetails/Charts/PollPerOptionChart.tsx
@@ -1,12 +1,30 @@
 import React from 'react'
-import { Bar, XAxis, YAxis } from 'recharts'
-import { Chart, ChartWrapper } from '../../common'
+import { Bar, XAxis, YAxis, Cell } from 'recharts'
+import { Chart, ChartWrapper, LegendLi } from '../../common'
+import { CustomSvg } from '../../common/Icon'
+import { defaultColors } from './'
 
 const PollPerOptionChart = props => {
-  const { wrapperProps, modalProps, isVoter } = props
+  const { wrapperProps, modalProps, isVoter, colors } = props
+  const chartColors = [...defaultColors, ...colors]
+
+  const renderLegend = props => {
+    const { data } = props
+    return (
+      <ul className="recharts-default-legend" style={{ listStyleType: 'none' }}>
+        {data.map((entry, index) => (
+          <LegendLi key={`item-${index}`}>
+            <CustomSvg color={chartColors[index]} />
+            <span>{entry.label}</span>
+          </LegendLi>
+        ))}
+      </ul>
+    )
+  }
+
   return (
     <ChartWrapper hideFilters {...wrapperProps}>
-      <Chart {...modalProps}>
+      <Chart {...modalProps} legend={renderLegend}>
         {isVoter && <YAxis yAxisId="0" datakey="voter" />}
         {!isVoter && <YAxis yAxisId="1" datakey="mkr" />}
         <XAxis dataKey="label" />
@@ -15,10 +33,13 @@ const PollPerOptionChart = props => {
             isAnimationActive={modalProps.data ? false : true}
             name={'Voters'}
             yAxisId="0"
-            dataKey="voter"
-            stackId="a"
             fill="#61b6b0"
-          />
+            dataKey="voter"
+          >
+            {modalProps.data.map((entry, index) => (
+              <Cell key={`cell-${index}`} fill={chartColors[index]} />
+            ))}
+          </Bar>
         )}
         {!isVoter && (
           <Bar
@@ -27,8 +48,11 @@ const PollPerOptionChart = props => {
             yAxisId="1"
             dataKey="mkr"
             stackId="a"
-            fill="#999999"
-          />
+          >
+            {modalProps.data.map((entry, index) => (
+              <Cell key={`cell-${index}`} fill={chartColors[index]} />
+            ))}
+          </Bar>
         )}
       </Chart>
     </ChartWrapper>

--- a/src/components/PollDetails/index.tsx
+++ b/src/components/PollDetails/index.tsx
@@ -193,6 +193,7 @@ function PollDetails(props: Props) {
 
     return (
       <PollPerOptionChart
+        colors={colors}
         modalProps={getModalProps(data.type, data.component, data.expanded)}
         wrapperProps={getWrapperProps(data)}
         isVoter={props.isVoter}

--- a/src/components/PollDetails/index.tsx
+++ b/src/components/PollDetails/index.tsx
@@ -14,6 +14,7 @@ import {
   StrippedTableRow,
   StrippedTableCell,
   ThreeRowGrid,
+  CenteredRowGrid,
   StrippedRowsContainer,
 } from '../common'
 import { getModalContainer } from '../../utils'
@@ -263,7 +264,7 @@ function PollDetails(props: Props) {
           )}
         </CardStyled>
       </ThreeRowGrid>
-      <ThreeRowGrid>
+      <CenteredRowGrid>
         <CardStyled>
           {mkrDistributionData.length === 0 ? (
             <Loading />
@@ -289,7 +290,7 @@ function PollDetails(props: Props) {
             </StrippedRowsContainer>
           </StrippedTableWrapper>
         </CardStyled>
-      </ThreeRowGrid>
+      </CenteredRowGrid>
 
       {isModalOpen && (
         <Modal isOpen={isModalOpen} isChart={isModalChart} closeModal={() => setModalOpen(false)}>

--- a/src/components/common/Icon/hat.svg
+++ b/src/components/common/Icon/hat.svg
@@ -1,16 +1,16 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="15" height="19" viewBox="0 0 15 19">
     <defs>
         <style>
-            .cls-1,.cls-2{fill:#fff !important}.cls-1{font-size:7px;font-family:OpenSans-Semibold,Open Sans;font-weight:600}
+            .cls-hat1,.cls-hat2{fill:#fff !important}.cls-1{font-size:7px;font-family:OpenSans-Semibold,Open Sans;font-weight:600}
         </style>
     </defs>
     <g id="hat" transform="translate(-158 -293)">
-        <text id="HAT-2" fill="fff" class="cls-1" data-name="HAT" transform="translate(159 310)">
+        <text id="HAT-2" fill="fff" class="cls-1 cls-hat1" data-name="HAT" transform="translate(159 310)">
             <tspan x="0" y="0">HAT</tspan>
         </text>
         <g id="hat-3" data-name="hat" transform="translate(158 293)">
-            <path id="Path_25" d="M83.269 88.49c3.826 0 4.592-1.516 4.586-1.518-.555-6.361-3.92-2.779-4.586-2.779s-4.032-3.581-4.586 2.779c-.006.002.76 1.518 4.586 1.518z" class="cls-2" data-name="Path 25" transform="translate(-76.269 -83.188)"/>
-            <path id="Path_26" d="M12.34 223.72a3.118 3.118 0 0 1-1.549 1.267A9.523 9.523 0 0 1 7 225.7a9.523 9.523 0 0 1-3.791-.709 3.118 3.118 0 0 1-1.549-1.271c-1.035.458-1.66 1.052-1.66 1.7 0 1.452 3.134 2.629 7 2.629s7-1.177 7-2.629c0-.648-.625-1.242-1.66-1.7z" class="cls-2" data-name="Path 26" transform="translate(0 -219.649)"/>
+            <path id="Path_25" d="M83.269 88.49c3.826 0 4.592-1.516 4.586-1.518-.555-6.361-3.92-2.779-4.586-2.779s-4.032-3.581-4.586 2.779c-.006.002.76 1.518 4.586 1.518z" class="cls-2 cls-hat2" data-name="Path 25" transform="translate(-76.269 -83.188)"/>
+            <path id="Path_26" d="M12.34 223.72a3.118 3.118 0 0 1-1.549 1.267A9.523 9.523 0 0 1 7 225.7a9.523 9.523 0 0 1-3.791-.709 3.118 3.118 0 0 1-1.549-1.271c-1.035.458-1.66 1.052-1.66 1.7 0 1.452 3.134 2.629 7 2.629s7-1.177 7-2.629c0-.648-.625-1.242-1.66-1.7z" class="cls-2 cls-hat2" data-name="Path 26" transform="translate(0 -219.649)"/>
         </g>
     </g>
 </svg>

--- a/src/components/common/Table/index.tsx
+++ b/src/components/common/Table/index.tsx
@@ -24,7 +24,7 @@ type TableProps = {
 
 const HatContainer = styled.span`
   position: absolute;
-  height: 49px;
+  height: 51px;
   width: 24px;
   top: 0;
   left: 0;
@@ -200,11 +200,11 @@ const RowsSection = styled.div`
   }
 `
 
-const ArrowSort = styled(({ up, ...props }) => <ArrowIcon {...props} />)`
+const ArrowSort = styled(({ up, hidden, ...props }) => <ArrowIcon {...props} />)`
   left: 5px;
   position: relative;
-  top: 1px;
   transform: ${props => (props.up ? 'rotate(180deg)' : 'rotate(0deg)')};
+  visibility: ${props => (props.hidden ? 'hidden' : 'visible')};
 `
 
 const Pagination = styled.div`
@@ -362,7 +362,15 @@ function Table({ columns, data, expanded, limitPerPage, scrollable, handleRow, s
                 <div>
                   <span {...column.getHeaderProps(column.getSortByToggleProps())}>
                     {column.render('Header')}
-                    {column.isSorted ? column.isSortedDesc ? <ArrowSort up={false} /> : <ArrowSort up={true} /> : ''}
+                    {column.isSorted ? (
+                      column.isSortedDesc ? (
+                        <ArrowSort up={false} />
+                      ) : (
+                        <ArrowSort up={true} />
+                      )
+                    ) : (
+                      <ArrowSort hidden />
+                    )}
                   </span>
                   {column.canFilter && (
                     <FilterIconContainer

--- a/src/components/common/index.tsx
+++ b/src/components/common/index.tsx
@@ -26,6 +26,7 @@ import {
   StrippedTableRow,
   ThreeRowGrid,
   TwoRowGrid,
+  CenteredRowGrid,
   Versus,
   ViewAll,
   LegendLi,
@@ -65,5 +66,6 @@ export {
   Versus,
   ViewAll,
   TwoRowGrid,
+  CenteredRowGrid,
   LegendLi,
 }

--- a/src/components/common/styled/index.tsx
+++ b/src/components/common/styled/index.tsx
@@ -179,6 +179,25 @@ export const ThreeRowGrid = styled.div`
   }
 `
 
+export const CenteredRowGrid = styled.div`
+  @media (max-width: ${props => props.theme.themeBreakPoints.xl}) {
+    column-gap: ${props => props.theme.separation.gridSeparation};
+    display: grid;
+    grid-template-columns: 1fr;
+    row-gap: ${props => props.theme.separation.gridSeparation};
+  }
+  @media (min-width: ${props => props.theme.themeBreakPoints.xl}) {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-around;
+    margin: 0 auto;
+    ${Card} {
+      width: 401px;
+      margin-right: ${props => props.theme.separation.gridSeparation};
+    }
+  }
+`
+
 export const TwoRowGrid = styled.div`
   column-gap: ${props => props.theme.separation.gridSeparation};
   display: grid;


### PR DESCRIPTION
*General Rules for horizontal ordering of columns within the executive and poll lists*

- While some columns differ, others are shared, we should try to keep the layout of columns as similar as possible between the two.
- Order should be: Status, Category (hidden for now), Name, **, Start, End/Executed. Poll/Executive specific columns should keep their current order arranged between Name and Start (where the * is in the order above).

*Main Dashboard*

- Change ‘uncasted executives’ to Uncast Executives.

*Executive List*

- It might be good to bold the ‘Active’ status only. It’s the most important status, it would be good to call more attention to it.
- Filter icon moves to the right after sorting ascending/descending.
- Category columns should be hidden until such a time as we can source metadata from the executive markdown.
- Hat icon does not correctly align with the row item in which it is placed.



*Poll List*

- Generally overcrowded. This is my fault. Suggested fixes are:
     - Remove category column temporarily (until we can actually assign metadata.)
     - Remove total MKR staked column, it fills a similar function as the percentage participation, but I think the 
     percentage expression of this number is probably more useful.
- Status filter should not show individual times remaining, it should show either ‘Active’ or ‘Ended’.
- There shouldn’t be a scroll bar (hopefully this is addressed through fixing the general real-estate problem described above.

Feedback : https://docs.google.com/document/d/1bPyIRztdeZ2hPx7u4gzhjmoT-ByBTxwNA9Z_KxROKNg/edit#

Estimation : https://docs.google.com/spreadsheets/d/1TLMUbAoyDzBFgh-7JhfWF5MvDxZ66wudtITPWsclocM/edit#gid=0