### PR TITLE
Executive Vote Details: Make exec vote details show new data

### DIFF
--- a/src/components/PollDetails/helpers.tsx
+++ b/src/components/PollDetails/helpers.tsx
@@ -2,14 +2,13 @@ import {
   fromUnixTime,
   getUnixTime,
   format,
-  differenceInDays,
   addHours,
   startOfHour,
   endOfHour,
   differenceInHours,
   isAfter,
 } from 'date-fns'
-import { shortenAccount, timeLeft, getVoterBalances, getVotersBalance, getPollData } from '../../utils'
+import { shortenAccount, timeLeft, getVoterBalances, getVotersBalance, getPollData, getTimeOpened } from '../../utils'
 import { getVoterAddresses, getPollDataWithoutBalances } from './data'
 import { LAST_YEAR } from '../../constants'
 
@@ -19,15 +18,6 @@ export const defaultFilters = {
 export const getTopVoters = async poll => {
   const balancesLookup = await getAllBalances(poll)
   return await getVotersBalance(poll, balancesLookup)
-}
-
-const getTimeOpened = (from, to) => {
-  const diffDays = differenceInDays(to, from)
-  const diffHours = differenceInHours(to, from) % 24
-  if (diffDays > 0 && diffHours > 0) {
-    return `${diffDays} ${diffDays === 1 ? 'day' : 'days'} ${diffHours} ${diffHours === 1 ? 'hour' : 'hours'}`
-  } else if (diffDays <= 0) return `${diffHours} ${diffHours === 1 ? 'hour' : 'hours'}`
-  else return `${diffDays} ${diffDays === 1 ? 'day' : 'days'}`
 }
 
 const getKeysWithHighestValue = (o, n) => {

--- a/src/components/VoteDetails/helpers.tsx
+++ b/src/components/VoteDetails/helpers.tsx
@@ -1,7 +1,7 @@
-import { fromUnixTime, format, formatDistanceToNow } from 'date-fns'
+import { fromUnixTime, format } from 'date-fns'
 import { utcToZonedTime } from 'date-fns-tz'
 import BigNumber from 'bignumber.js'
-import { shortenAccount, getHourlyFromTo } from '../../utils'
+import { shortenAccount, getHourlyFromTo, getTimeOpened } from '../../utils'
 import {
   LAST_YEAR,
   VOTING_ACTION_FREE,
@@ -16,12 +16,13 @@ export const getVoteTableData = vote => {
     : new Date(vote.date)
   const mkr_approvals = vote.approvals ? Number(vote.approvals).toFixed(2) : vote.end_approvals
   return [
-    { value: shortenAccount(vote.id), label: 'Source' },
-    { value: format(startDate, 'P'), label: 'Started' },
-    { value: mkr_approvals ? 'Yes' : 'No', label: 'Voted' },
-    { value: vote.casted ? 'Yes' : 'No', label: 'Ended' },
-    { value: vote.casted ? 'Closed' : 'Active', label: 'Status' },
-    { value: formatDistanceToNow(startDate, { addSuffix: false }), label: 'Time opened' },
+    { value: shortenAccount(vote.id), label: 'Spell Address' },
+    { value: format(startDate, 'P'), label: 'Start Date' },
+    { value: vote.casted ? 'Passed' : 'Open', label: 'Status' },
+    {
+      value: vote.casted ? getTimeOpened(startDate, fromUnixTime(vote.casted)) : getTimeOpened(startDate, Date.now()),
+      label: 'Time opened',
+    },
     { value: mkr_approvals, label: 'MKR in support' },
     { value: vote.casted ? 'Yes' : 'No', label: 'Executed' },
   ]

--- a/src/utils/index.tsx
+++ b/src/utils/index.tsx
@@ -321,3 +321,12 @@ export const getPollsBalances = async polls => {
     }
   }, {})
 }
+
+export const getTimeOpened = (from, to) => {
+  const diffDays = differenceInDays(to, from)
+  const diffHours = differenceInHours(to, from) % 24
+  if (diffDays > 0 && diffHours > 0) {
+    return `${diffDays} ${diffDays === 1 ? 'day' : 'days'} ${diffHours} ${diffHours === 1 ? 'hour' : 'hours'}`
+  } else if (diffDays <= 0) return `${diffHours} ${diffHours === 1 ? 'hour' : 'hours'}`
+  else return `${diffDays} ${diffDays === 1 ? 'day' : 'days'}`
+}


### PR DESCRIPTION
The executive details tile should show the following:

- Spell Address - Address of the proposal spell.
- Start Date - Date on which the proposal was posted.
- Status - Open/Passed
- Time Open - How many days + hours has this been open.
- MKR in Support - # of MKR Staked
- Executed - Yes/No