### PR TITLE
Add missing Executive Metadata

### DIFF
--- a/src/containers/Executive/index.tsx
+++ b/src/containers/Executive/index.tsx
@@ -44,10 +44,10 @@ function ExecutiveInfo(props) {
   useEffect(() => {
     if (excutivesData.data && excutivesData.data.spells) {
       getMakerDaoData()
-        .then(({ executiveVotes }) => {
+        .then(({ spellsInfo }) => {
           setData(
             excutivesData.data.spells.map(spell => {
-              const proposal = executiveVotes.find(prop => {
+              const proposal = spellsInfo.find(prop => {
                 return prop.source.toLowerCase() === spell.id.toLowerCase()
               })
               return {

--- a/src/containers/Vote/index.tsx
+++ b/src/containers/Vote/index.tsx
@@ -34,8 +34,8 @@ function VoteInfo(props: Props) {
 
   useEffect(() => {
     getMakerDaoData()
-      .then(({ executiveVotes }) => {
-        const vote = executiveVotes.find(el => {
+      .then(({ spellsInfo }) => {
+        const vote = spellsInfo.find(el => {
           return el.source.toLowerCase() === voteId.toLowerCase()
         })
         setMakerData(vote)

--- a/src/containers/VoterHistory/index.tsx
+++ b/src/containers/VoterHistory/index.tsx
@@ -123,10 +123,10 @@ function VoterHistory(props: Props) {
   useEffect(() => {
     if (historyData.data && historyData.data.executives) {
       getMakerDaoData()
-        .then(({ executiveVotes }) => {
+        .then(({ spellsInfo }) => {
           setExecutives(exs =>
             exs.map(spell => {
-              const proposal = executiveVotes.find(prop => prop.source.toLowerCase() === spell.id.toLowerCase())
+              const proposal = spellsInfo.find(prop => prop.source.toLowerCase() === spell.id.toLowerCase())
               return {
                 ...spell,
                 ...proposal,

--- a/src/utils/makerdao.ts
+++ b/src/utils/makerdao.ts
@@ -3,7 +3,7 @@ import BigNumber from 'bignumber.js'
 import { getUnixTime } from 'date-fns'
 const Hash = require('ipfs-only-hash')
 
-const network = 'mainnet'
+// const network = 'mainnet'
 const prod = 'https://cms-gov.makerfoundation.com'
 const topicsPath = 'content/governance-dashboard'
 const spellsPath = 'content/all-spells'

--- a/src/utils/makerdao.ts
+++ b/src/utils/makerdao.ts
@@ -3,7 +3,6 @@ import BigNumber from 'bignumber.js'
 import { getUnixTime } from 'date-fns'
 const Hash = require('ipfs-only-hash')
 
-// const network = 'mainnet'
 const prod = 'https://cms-gov.makerfoundation.com'
 const topicsPath = 'content/governance-dashboard'
 const spellsPath = 'content/all-spells'
@@ -53,21 +52,6 @@ const fetchTopics = async network => {
 const fetchSpells = async network => {
   return fetchNetwork(prod, 'spells', spellsPath, network)
 }
-
-// function extractProposals(topics, network) {
-//   const executiveTopics = topics.filter(t => t.govVote === false)
-//   return executiveTopics.reduce((acc, topic) => {
-//     const proposals = topic.proposals.map(({ source, ...otherProps }) => ({
-//       ...otherProps,
-//       source: source.startsWith('{') ? JSON.parse(source)[network] : source,
-//       active: topic.active,
-//       govVote: topic.govVote,
-//       topicKey: topic.key,
-//       topicTitle: topic.topic,
-//     }))
-//     return acc.concat(proposals)
-//   }, [])
-// }
 
 export const formatHistoricalPolls = topics => {
   const govTopics = topics.filter(t => t.govVote === true)
@@ -120,7 +104,7 @@ export async function getMakerDaoData() {
     about,
   }))
 
-  return { /*executiveVotes,*/ historicalPolls, spellsInfo }
+  return { historicalPolls, spellsInfo }
 }
 
 // Polls data

--- a/src/utils/makerdao.ts
+++ b/src/utils/makerdao.ts
@@ -4,7 +4,6 @@ import { getUnixTime } from 'date-fns'
 const Hash = require('ipfs-only-hash')
 
 const prod = 'https://cms-gov.makerfoundation.com'
-const topicsPath = 'content/governance-dashboard'
 const spellsPath = 'content/all-spells'
 const rawUri = 'https://raw.githubusercontent.com/makerdao/community/master/governance/polls'
 
@@ -45,10 +44,6 @@ const fetchNetwork = async (url, resource, path, network = 'mainnet') => {
   return await res.json()
 }
 
-const fetchTopics = async network => {
-  return fetchNetwork(prod, 'topics', topicsPath, network)
-}
-
 const fetchSpells = async network => {
   return fetchNetwork(prod, 'spells', spellsPath, network)
 }
@@ -83,20 +78,12 @@ export const formatHistoricalPolls = topics => {
 }
 
 export async function getMakerDaoData() {
-  const topics = await promiseRetry({
-    fn: fetchTopics,
-    times: 4,
-    delay: 1,
-  })
-
   const allSpells = await promiseRetry({
     fn: fetchSpells,
     times: 4,
     delay: 1,
   })
 
-  //const executiveVotes = extractProposals(topics, network)
-  const historicalPolls = formatHistoricalPolls(topics)
   const spellsInfo = allSpells.map(({ source, title, proposal_blurb, about }) => ({
     source,
     title,
@@ -104,7 +91,7 @@ export async function getMakerDaoData() {
     about,
   }))
 
-  return { historicalPolls, spellsInfo }
+  return { spellsInfo }
 }
 
 // Polls data

--- a/src/utils/makerdao.ts
+++ b/src/utils/makerdao.ts
@@ -54,20 +54,20 @@ const fetchSpells = async network => {
   return fetchNetwork(prod, 'spells', spellsPath, network)
 }
 
-function extractProposals(topics, network) {
-  const executiveTopics = topics.filter(t => t.govVote === false)
-  return executiveTopics.reduce((acc, topic) => {
-    const proposals = topic.proposals.map(({ source, ...otherProps }) => ({
-      ...otherProps,
-      source: source.startsWith('{') ? JSON.parse(source)[network] : source,
-      active: topic.active,
-      govVote: topic.govVote,
-      topicKey: topic.key,
-      topicTitle: topic.topic,
-    }))
-    return acc.concat(proposals)
-  }, [])
-}
+// function extractProposals(topics, network) {
+//   const executiveTopics = topics.filter(t => t.govVote === false)
+//   return executiveTopics.reduce((acc, topic) => {
+//     const proposals = topic.proposals.map(({ source, ...otherProps }) => ({
+//       ...otherProps,
+//       source: source.startsWith('{') ? JSON.parse(source)[network] : source,
+//       active: topic.active,
+//       govVote: topic.govVote,
+//       topicKey: topic.key,
+//       topicTitle: topic.topic,
+//     }))
+//     return acc.concat(proposals)
+//   }, [])
+// }
 
 export const formatHistoricalPolls = topics => {
   const govTopics = topics.filter(t => t.govVote === true)
@@ -111,7 +111,7 @@ export async function getMakerDaoData() {
     delay: 1,
   })
 
-  const executiveVotes = extractProposals(topics, network)
+  //const executiveVotes = extractProposals(topics, network)
   const historicalPolls = formatHistoricalPolls(topics)
   const spellsInfo = allSpells.map(({ source, title, proposal_blurb, about }) => ({
     source,
@@ -120,7 +120,7 @@ export async function getMakerDaoData() {
     about,
   }))
 
-  return { executiveVotes, historicalPolls, spellsInfo }
+  return { /*executiveVotes,*/ historicalPolls, spellsInfo }
 }
 
 // Polls data


### PR DESCRIPTION
Use the new `https://cms-gov.makerfoundation.com/content/all-spells` endpoint to fetch missing spells metadata.