### PR TITLE
Fix missing callback in linkable component

### DIFF
--- a/src/components/common/LinkableComponent/index.tsx
+++ b/src/components/common/LinkableComponent/index.tsx
@@ -13,7 +13,10 @@ export default function LinkableComponent({ children, id }) {
     (fn: Function) => {
       if (initialized) return
 
-      fn()
+      if (fn) {
+        fn()
+      }
+
       setInitialized(true)
     },
     [initialized],


### PR DESCRIPTION
This fixes the case where metrics don't have a fullscreen modal (e.g. Top Supporters in Executive vote detail) and an empty function is passed for init.